### PR TITLE
(mypage・histoly-list)：褒め言葉未作成時のUI作成

### DIFF
--- a/src/app/mypage/history-list/history-list.component.html
+++ b/src/app/mypage/history-list/history-list.component.html
@@ -1,1 +1,25 @@
-<app-history-card *ngFor="let message of messages$ | async" [message]="message"></app-history-card>
+<ng-container *ngIf="messages$ | async as HistoryWithMessage; else default">
+  <app-history-card
+    *ngFor="let message of messages$ | async"
+    [message]="message"
+  ></app-history-card>
+  <div class="actions">
+    <a
+      href="https://github.com/apps/gitcheerapp"
+      target="_blank"
+      class="dictionary-btn"
+      >Githubリポジトリに連携する</a
+    >
+  </div>
+</ng-container>
+<ng-template #default>
+  <p class="register">褒め言葉を辞書に登録しよう！</p>
+  <div class="actions">
+    <a
+      href="https://github.com/apps/gitcheerapp"
+      target="_blank"
+      class="dictionary-btn"
+      >他のGithubリポジトリと連携</a
+    >
+  </div>
+</ng-template>

--- a/src/app/mypage/history-list/history-list.component.scss
+++ b/src/app/mypage/history-list/history-list.component.scss
@@ -1,0 +1,33 @@
+@import 'variables';
+@import 'mixins';
+
+.register {
+  text-align: center;
+  font-size: 18px;
+  margin-bottom: 32px;
+}
+
+.actions {
+  margin: 16px 0 24px;
+  padding: 0 16px;
+  text-align: center;
+  @include pc {
+    padding: 0 24px;
+  }
+}
+
+.dictionary-btn {
+  cursor: pointer;
+  text-decoration: none;
+  background-color: $color-btn;
+  border: none;
+  color: #fff;
+  transition: opacity 0.4s;
+  font-size: 16px;
+  padding: 12px 28px;
+  border-radius: 40px;
+  line-height: 1;
+  &:hover {
+    opacity: 0.6;
+  }
+}

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -3,9 +3,7 @@
     <h1>褒められ履歴☺️</h1>
   </div>
   <app-history-list></app-history-list>
-  <div class="mypage__actions">
-    <a href="https://github.com/apps/gitcheerapp" target="_blank" class="mypage__btn-github-setup">Githubリポジトリに連携する</a>
-  </div>
+
   <div routerlink="/settings" class="mypage__dictionary">
     <button class="mypage__dictionary-btn">褒め言葉辞書</button>
   </div>


### PR DESCRIPTION
fix #49 

## 作業内容
褒め言葉未作成時のUIを作成しました。
以下作業内容です。
＊ボタンのコメント等は任意で変更頂ければと思います。よろしくお願いします。

- [x] 褒め言葉未作成時のUI作成
- [x] mypageからhistory-listにボタンを移植

## img
## 褒め言葉作成時
<img width="407" alt="スクリーンショット 2020-12-06 3 53 18" src="https://user-images.githubusercontent.com/61979156/101260919-95926500-3776-11eb-9bb7-f06abc736299.png">


## 褒め言葉未作成時
<img width="401" alt="スクリーンショット 2020-12-06 3 54 41" src="https://user-images.githubusercontent.com/61979156/101260953-c7a3c700-3776-11eb-8cb9-31460b9d4cee.png">

